### PR TITLE
[FND-3437] Upgrade upload-artifact action to 4.4.3

### DIFF
--- a/.github/workflows/build_batch_release.yml
+++ b/.github/workflows/build_batch_release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Build gem source
       run:  ruby .scripts/batch_build.rb
     - name: Archive Artifacts
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: ${{ github.sha }}
         path: sentry*/*.gem

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -27,7 +27,7 @@ jobs:
       working-directory: ${{env.sdk-directory}}
       run: make build
     - name: Archive Artifacts
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: ${{ github.sha }}
         path: ${{env.sdk-directory}}/*.gem


### PR DESCRIPTION
The [breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) shouldn't affect us.